### PR TITLE
add rudimentary Gitlab authenticator

### DIFF
--- a/helm-chart/images/kubessh/kubessh_config.py
+++ b/helm-chart/images/kubessh/kubessh_config.py
@@ -1,4 +1,7 @@
 from ruamel.yaml import YAML
+from kubessh.authentication.github import GitHubAuthenticator
+from kubessh.authentication.gitlab import GitLabAuthenticator
+from kubessh.authentication.dummy import DummyAuthenticator
 
 yaml = YAML()
 
@@ -9,7 +12,14 @@ with open('/etc/kubessh/config/values.yaml') as f:
     config = yaml.load(f)
 
 if config['auth']['type'] == 'github':
-    c.GitHubAuthenticator.allowed_users = config['auth']['github']['allowedUsers']
+    c.KubeSSH.authenticator_class = GitHubAuthenticator
+    c.KubeSSH.authenticator_class.allowed_users = config['auth']['github']['allowedUsers']
+elif config['auth']['type'] == 'gitlab':
+    c.KubeSSH.authenticator_class = GitLabAuthenticator
+    c.KubeSSH.authenticator_class.instance_url = config['auth']['gitlab']['instanceUrl']
+elif config['auth']['type'] == 'dummy':
+    c.KubeSSH.authenticator_class = DummyAuthenticator
+
 
 if 'podTemplate' in config:
     c.UserPod.pod_template = config['podTemplate']

--- a/helm-chart/images/kubessh/kubessh_config.py
+++ b/helm-chart/images/kubessh/kubessh_config.py
@@ -17,6 +17,8 @@ if config['auth']['type'] == 'github':
 elif config['auth']['type'] == 'gitlab':
     c.KubeSSH.authenticator_class = GitLabAuthenticator
     c.KubeSSH.authenticator_class.instance_url = config['auth']['gitlab']['instanceUrl']
+    c.KubeSSH.authenticator_class.allowed_users = config['auth']['gitlab']['allowedUsers']
+
 elif config['auth']['type'] == 'dummy':
     c.KubeSSH.authenticator_class = DummyAuthenticator
 

--- a/kubessh/authentication/gitlab.py
+++ b/kubessh/authentication/gitlab.py
@@ -1,0 +1,40 @@
+from kubessh.authentication import Authenticator
+import async_timeout
+import aiohttp
+import asyncssh
+import re
+from traitlets import Unicode
+
+class GitLabAuthenticator(Authenticator):
+    """
+    Authenticate with GitLab SSH keys
+    """
+    instance_url = Unicode(
+        "",
+        config=True,
+        help="""
+        URL to the Gitlab instance whose users should be able to authenticate with public keys.
+        """
+    )
+
+    def connection_made(self, conn):
+        self.conn = conn
+
+    def public_key_auth_supported(self):
+        return True
+
+    async def begin_auth(self, username):
+        """
+        Fetch and save user's keys for comparison later
+        """
+        import sys
+        url = f'{self.instance_url}/{username}.keys'
+        async with aiohttp.ClientSession() as session, async_timeout.timeout(5):
+            async with session.get(url) as response:
+                keys = await response.text()
+        if keys:
+            # Remove comment fields from SSH keys, as asyncssh seems to choke on those
+            keys = "\n".join(re.findall("^[^ ]+ [^ ]+", keys, flags=re.M))
+            self.conn.set_authorized_keys(asyncssh.import_authorized_keys(keys))
+        # Return true to indicate we always *must* authenticate
+        return True


### PR DESCRIPTION
Add a basic Gitlab authenticator that allows all public keys users have added to
their account, just like the Github one; the only difference for now is the
ability to specify a URL to a self-hosted Gitlab instance. Future API-based
functionality may be worthwile, such as allowing access control via Gitlab user
groups.