### PR TITLE
add basic SFTP support

### DIFF
--- a/helm-chart/images/kubessh/Dockerfile
+++ b/helm-chart/images/kubessh/Dockerfile
@@ -1,7 +1,13 @@
 FROM python:3.8
 
-RUN curl -L https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl
+RUN set -x \
+  &&  curl -L https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl \
+  && chmod +x /usr/local/bin/kubectl
+
+RUN set -x \
+  && mkdir -vp /usr/local/share/kubessh \
+  && curl -L https://github.com/mvoelske/static-openssh-sftp-server/releases/download/v0.1.0/sftp-server > /usr/local/share/kubessh/sftp-server \
+  && chmod +x /usr/local/share/kubessh/sftp-server
 
 COPY . /srv/kubessh
 COPY helm-chart/images/kubessh/kubessh_config.py /srv/kubessh

--- a/helm-chart/images/kubessh/kubessh_config.py
+++ b/helm-chart/images/kubessh/kubessh_config.py
@@ -30,3 +30,9 @@ if 'podTemplate' in config:
 
 if 'pvcTemplates' in config:
     c.UserPod.pvc_templates = config['pvcTemplates']
+
+if 'sftpBinaryUploadPath' in config:
+    c.KubeSFTPServerHandler.sftp_binary_upload_path = config['sftpBinaryUploadPath']
+
+if 'sftpBinarySourcePath' in config:
+    c.KubeSFTPServerHandler.sftp_binary_source_path = config['sftpBinarySourcePath']

--- a/kubessh/app.py
+++ b/kubessh/app.py
@@ -16,6 +16,7 @@ from kubessh.pod import UserPod, PodState
 from kubessh.authentication import Authenticator
 from kubessh.authentication.github import GitHubAuthenticator
 
+import kubessh.sftp # unused, sets up the asyncssh wiring
 
 class KubeSSH(Application):
     config_file = Unicode(
@@ -136,7 +137,8 @@ class KubeSSH(Application):
             server_host_keys=[self.ssh_host_key],
             encoding=None,
             agent_forwarding=False, # The cause of so much pain! Let's not allow this by default
-            keepalive_interval=30 # FIXME: Make this configurable
+            keepalive_interval=30, # FIXME: Make this configurable
+            sftp_factory=True
         )
 
 app = KubeSSH()

--- a/kubessh/sftp.py
+++ b/kubessh/sftp.py
@@ -1,0 +1,164 @@
+import sys
+import os
+import asyncssh.sftp
+import subprocess
+from kubessh.pod import UserPod
+from traitlets import Unicode
+from traitlets.config import LoggingConfigurable
+
+class DelegateSFTPServerHandler(asyncssh.sftp.SFTPServerHandler):
+    """An SFTP server session handler that delegates all SFTP-related
+    communication to a subprocess.
+    """
+    def __init__(self, server, reader, writer):
+        super().__init__(server, reader, writer)
+        self.username = server.channel.get_extra_info('username')
+        self._init_delegate()
+        self.logger.info(f"Initialized {self.__class__} for {self.username}")
+
+    def _init_delegate(self):
+        self._proc = subprocess.Popen(
+            ['./sftp-server'],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=sys.stderr
+        )
+        self._proc_stdin = self._proc.stdin
+        self._proc_stdout = self._proc.stdout
+
+    async def _cleanup(self, exc):
+        self._proc.terminate()
+        await super()._cleanup(exc)
+
+    async def _forward_incoming_packet_to_delegate(self, data):
+        self.logger.debug1(f'write {len(data)} byte packet to delegate process')
+        self.logger.debug2(f'{data}')
+        self._proc_stdin.write(
+            len(data).to_bytes(length=4, byteorder='big', signed=False))
+        self._proc_stdin.write(data)
+        self._proc_stdin.flush()
+
+    async def _read_packet_from_delegate(self):
+        self.logger.debug1('read packet from delegate process')
+        ch = self._proc_stdout
+        self.logger.debug2('read packet length field')
+        pkt_len = int.from_bytes(ch.peek()[:4], byteorder='big', signed=False)
+        self.logger.debug2(f'attempt to read {pkt_len} byte packet')
+        packet = ch.read(pkt_len + 4)
+        self.logger.debug2(f'delegate packet is {packet}')
+        return packet
+
+    async def _forward_outgoing_packet_from_delegate(self, data):
+        self._writer.write(data)
+
+    async def _process_packet(self, pkttype, pktid, packet):
+        self.log_received_packet(pkttype, pktid, packet, note='forwarded to subprocess')
+        await self._forward_incoming_packet_to_delegate(packet.get_full_payload())
+        response = await self._read_packet_from_delegate()
+        # TODO: (would have to redundantly decode packet to log it, omitted for now)
+        #self.log_sent_packet(pkttype, pktid, packet, note='forwarded from subprocess')
+        await self._forward_outgoing_packet_from_delegate(response)
+
+    async def run(self):
+        # skip super's SFTP init handling, the subprocess does this here
+        await self.recv_packets()
+
+
+class KubeSFTPServerHandler(DelegateSFTPServerHandler, LoggingConfigurable):
+
+    # where the SFTP binary lives in the KubeSSH server image
+    sftp_binary_source_path = Unicode(
+        '/usr/local/share/kubessh/sftp-server',
+        allow_none=False,
+        help="""
+        Path in the KubeSSH server container to the static sftp-server binary.
+        """,
+        config=True
+    )
+
+    # where the SFTP binary goes in the user pod
+    sftp_binary_upload_path = Unicode(
+        '.local/sbin/kubessh-sftp-server',
+        allow_none=False,
+        help="""
+        Path inside the user pod where the sftp-server binary will be uploaded.
+
+        Must be full path including the executable name, and can be absolute or
+        relative to the working dir. Must be writable by the user the pod runs
+        as.
+        """,
+        config=True
+    )
+
+    def __init__(self, server, reader, writer):
+        from kubessh.app import app
+        super(LoggingConfigurable, self).__init__(parent=app)
+        super().__init__(server, reader, writer)
+
+    def _run_setup_command(self, *kubectl_command):
+        self.logger.info(f'executing: {kubectl_command}')
+        cmd = subprocess.Popen(kubectl_command)
+        return cmd.wait()
+
+    def _init_delegate(self):
+        self.namespace = self.parent.default_namespace
+        self.pod_name = UserPod(
+            parent=self.parent, namespace=self.namespace,
+            username=self.username).pod_name
+        # ensure sftp-server binary is copied into the user pod
+        self._run_setup_command(
+            'kubectl',
+            '--namespace', self.namespace,
+            'exec',
+            '-c', 'shell',
+            self.pod_name,
+            '--', 'mkdir', '-p',
+            os.path.dirname(self.sftp_binary_upload_path))
+        self._run_setup_command(
+            'kubectl', 'cp',
+            self.sftp_binary_source_path,
+            f'{self.namespace}/{self.pod_name}:{self.sftp_binary_upload_path}',
+            '-c', 'shell')
+        self._run_setup_command(
+            'kubectl',
+            '--namespace', self.namespace,
+            'exec',
+            '-c', 'shell',
+            self.pod_name,
+            '--', 'chmod', '+x', self.sftp_binary_upload_path)
+
+        # start sftp-server binary and redirect stdin/stdout
+        kubectl_command = [
+            'kubectl',
+            '--namespace', self.namespace,
+            'exec',
+            '-c', 'shell',
+            '--stdin',
+            self.pod_name,
+            '--', self.sftp_binary_upload_path
+        ]
+        self.logger.info(f'starting delegate sftp-server process: {kubectl_command}')
+
+        self._proc = subprocess.Popen(
+            kubectl_command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=sys.stderr
+        )
+        self._proc_stdin = self._proc.stdin
+        self._proc_stdout = self._proc.stdout
+
+
+
+## XXX: as of asyncssh v2.2.1, there appears to be no proper way to override
+## the default SFTPServerHandler implementation. The below monkey-patching
+## works for now, but should be replaced once there is a better way to do this.
+
+import asyncssh.stream
+import asyncssh.sftp
+
+def run_override(sftp_server, reader, writer):
+    return KubeSFTPServerHandler(sftp_server, reader, writer).run()
+
+asyncssh.sftp.run_sftp_server = run_override
+asyncssh.stream.run_sftp_server = run_override


### PR DESCRIPTION
See https://github.com/yuvipanda/kubessh/issues/26

This adds basic support for SFTP by delegating to an OpenSSH sftp-server subsystem running
in the user pod. Kind of work-in-progress: Getting this to work with asyncssh is a little ugly at the moment, and involves monkey-patching a function in the asyncssh code. SFTP file transfers into and out of the user pod work fine in my initial trials so far, but are a bit slow (<10 MB/s over a gigabit line), maybe due to the rather verbose logging. SCP doesn't work, yet -- if you simply set `allow_scp=True`, the SCP file transfers end up in the kubessh pod instead of the user pod. Also not 100% sure if downloading the `sftp-server` binary from github during the docker build is the best way to get it in there. Comments welcome :)



