### PR TITLE
add rbac permission for handling persistent volumes

### DIFF
--- a/helm-chart/kubessh/templates/rbac.yaml
+++ b/helm-chart/kubessh/templates/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["pods", "pods/exec", "pods/portforward"]
+  resources: ["pods", "pods/exec", "pods/portforward", "persistentvolumeclaims"]
   verbs: ["get", "watch", "list", "create", "delete"]
 ---
 kind: RoleBinding

--- a/kubessh/pod.py
+++ b/kubessh/pod.py
@@ -5,6 +5,7 @@ from ptyprocess import PtyProcess
 import time
 import argparse
 import os
+import sys
 from kubernetes import client as k
 import kubernetes.config
 import escapism


### PR DESCRIPTION
I realized the persistentvolumeclaims permission is required in order for the PVC-template code to work with RBAC enabled.